### PR TITLE
fix click handlers being bound twice

### DIFF
--- a/pages/pools.html
+++ b/pages/pools.html
@@ -82,7 +82,7 @@
 <br />
 
 <div class="table-responsive">
-    <table id="network-hash" class="table table-hover sortable">
+    <table id="network-hash" class="table table-hover">
         <thead>
             <tr>
                 <th><span id="symbol"></span> Pools</th>


### PR DESCRIPTION
This was causing a bug where in chrome you'd be able to sort once, but it seemed to stop reverse sorting. It was actually reverse sorting and re-sorting ascending again on a single click because the sort click handler was being bound twice because we're loading via both classname and explicitly in the pools JS.

keeping the explicit call as main, because FF doesn't seem to like the classname loading for this lib