### PR TITLE
Commas, Commas Everywhere!

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -6,6 +6,16 @@ var style_cookie_name = "style";
 var style_cookie_duration = 365;
 var style_domain = window.location.hostname;
 
+
+var renderDate = function(d) {
+    return ('0' + d.getDate()).slice(-2) + '-' +
+        ('0' + (d.getMonth() + 1)).slice(-2) + '-' +
+        d.getFullYear() + ' ' +
+        ('0' + d.getHours()).slice(-2) + ':' +
+        ('0' + d.getMinutes()).slice(-2);
+};
+
+
 $(document).ready(function() {
     if (donationAddress !== undefined && donationAddress !== "") {
         $("#donations").show();
@@ -99,7 +109,11 @@ function updateTextLinkable(elementId, text){
 
 var currentPage;
 var lastStats;
+var numberFormatter = new Intl.NumberFormat('en-US'); // US formatting, force commas.
 
+function localizeNumber(number) {
+    return numberFormatter.format(number);
+}
 
 function getReadableHashRateString(hashrate){
     var i = 0;
@@ -108,7 +122,7 @@ function getReadableHashRateString(hashrate){
         hashrate = hashrate / 1000;
         i++;
     }
-    return hashrate.toFixed(2) + byteUnits[i];
+    return localizeNumber(hashrate.toFixed(2)) + byteUnits[i];
 }
 
 function getReadableDifficultyString(difficulty, precision){
@@ -119,7 +133,7 @@ function getReadableDifficultyString(difficulty, precision){
     if (units[number] === undefined || units[number] === null) {
         return 0
     }
-    return (difficulty / Math.pow(1000, Math.floor(number))).toFixed(precision) + ' ' +  units[number];
+    return localizeNumber((difficulty / Math.pow(1000, Math.floor(number))).toFixed(precision)) + ' ' +  units[number];
 }
 
 function formatBlockLink(hash){
@@ -128,12 +142,12 @@ function formatBlockLink(hash){
 
 function getReadableCoins(coins, digits, withoutSymbol){
     var amount = (parseInt(coins || 0) / coinUnits).toFixed(digits || coinUnits.toString().length - 1);
-    return amount + (withoutSymbol ? '' : (' ' + symbol));
+    return localizeNumber(amount) + (withoutSymbol ? '' : (' ' + symbol));
 }
 
 function formatDate(time){
     if (!time) return '';
-    return new Date(parseInt(time) * 1000).toLocaleString();
+    return renderDate(new Date(parseInt(time) * 1000));
 }
 
 function formatPaymentLink(hash){

--- a/js/pools.js
+++ b/js/pools.js
@@ -32,14 +32,6 @@ var calculateTotalFee = function(config) {
     return totalFee;
 };
 
-var renderDate = function(d) {
-    return ('0' + d.getDate()).slice(-2) + '-' +
-        ('0' + (d.getMonth() + 1)).slice(-2) + '-' +
-        d.getFullYear() + ' ' +
-        ('0' + d.getHours()).slice(-2) + ':' +
-        ('0' + d.getMinutes()).slice(-2);
-};
-
 var renderPoolRow = function(host, name, data, d) {
 
     var agostring = $.timeago(d);
@@ -49,9 +41,9 @@ var renderPoolRow = function(host, name, data, d) {
 
     pools_row.push('<tr>');
     pools_row.push('<td id=host-'+name+'><a target=blank href=http://'+host+'>'+name+'</a></td>');
-    pools_row.push('<td class="height" id=height-'+name+'>'+data.network.height+'</td>');
-    pools_row.push('<td id=hashrate-'+name+'>'+data.pool.hashrate+' H/s</td>');
-    pools_row.push('<td id=miners-'+name+'>'+data.pool.miners+'</td>');
+    pools_row.push('<td class="height" id=height-'+name+'>'+localizeNumber(data.network.height)+'</td>');
+    pools_row.push('<td id=hashrate-'+name+'>'+localizeNumber(data.pool.hashrate)+' H/s</td>');
+    pools_row.push('<td id=miners-'+name+'>'+localizeNumber(data.pool.miners)+'</td>');
     pools_row.push('<td id=totalFee-'+name+'>'+calculateTotalFee(data)+'%</td>');
     pools_row.push('<td id=minPayout-'+name+'>'+getReadableCoins(data.config.minPaymentThreshold,2)+'</td>');
     pools_row.push('<td><span id=lastFound-'+name+'>'+datestring+'</span> (<span class="timeago" id="ago-'+name+'">'+agostring+'</span>)</td>');
@@ -94,7 +86,7 @@ NETWORK_STAT_MAP.forEach(function(url, host, map) {
         totalMiners += parseInt(data.pool.miners);
 
         updateText('totalPoolsHashrate', getReadableHashRateString(totalHashrate) + '/sec');
-        updateText('total_miners', totalMiners);
+        updateText('total_miners', localizeNumber(totalMiners));
 
         poolStats.push([poolName, parseInt(data.pool.hashrate), colorHash.hex(poolName)]);
 
@@ -128,12 +120,12 @@ NETWORK_STAT_MAP2.forEach(function(url, host, map) {
         totalMiners += parseInt(data.pool_statistics.miners);
 
         updateText('totalPoolsHashrate', getReadableHashRateString(totalHashrate) + '/sec');
-        updateText('total_miners', totalMiners);
+        updateText('total_miners', localizeNumber(totalMiners));
 
         poolStats.push([poolName, data.pool_statistics.hashRate, colorHash.hex(poolName)]);
 
         $.getJSON(url + '/network/stats', function(data, textStatus, jqXHR) {
-            updateText('height-'+poolName, data.height);
+            updateText('height-'+poolName, localizeNumber(data.height));
         });
 
         $.getJSON(url + '/config', function(data, textStatus, jqXHR) {
@@ -207,7 +199,7 @@ function displayChart() {
                 label: function (tooltipItem, data) {
                     var amount = data.datasets[tooltipItem.datasetIndex].data[tooltipItem.index];
                     var total = eval(data.datasets[tooltipItem.datasetIndex].data.join('+'));
-                    return amount + ' / ' + total + ' H/s  (' + parseFloat(amount * 100 / total).toFixed(2) + '%)';
+                    return localizeNumber(amount) + ' / ' + localizeNumber(total) + ' H/s  (' + parseFloat(amount * 100 / total).toFixed(2) + '%)';
                 }
             }
         }
@@ -246,13 +238,13 @@ setInterval(function(){
             totalHashrate += parseInt(data.pool.hashrate);
             totalMiners += parseInt(data.pool.miners);
 
-            updateText('height-'+poolName, data.network.height);
-            updateText('hashrate-'+poolName, data.pool.hashrate+' H/s');
-            updateText('miners-'+poolName, data.pool.miners);
+            updateText('height-'+poolName, localizeNumber(data.network.height));
+            updateText('hashrate-'+poolName, localizeNumber(data.pool.hashrate)+' H/s');
+            updateText('miners-'+poolName, localizeNumber(data.pool.miners));
             updateText('lastFound-'+poolName, datestring);
             updateText('ago-'+poolName, agostring);
             updateText('totalPoolsHashrate', getReadableHashRateString(totalHashrate) + '/sec');
-            updateText('total_miners', totalMiners);
+            updateText('total_miners', localizeNumber(totalMiners));
             updateText('networkHashrate', getReadableHashRateString(lastStats.difficulty / blockTargetInterval) + '/sec');
             updateText('networkDifficulty', getReadableDifficultyString(lastStats.difficulty, 0).toString());
 
@@ -282,19 +274,19 @@ setInterval(function(){
             var datestring = renderDate(d);
             var agostring = $.timeago(d);
 
-            updateText('hashrate-'+poolName, data.pool_statistics.hashRate+' H/s');
-            updateText('miners-'+poolName, data.pool_statistics.miners);
+            updateText('hashrate-'+poolName, localizeNumber(data.pool_statistics.hashRate)+' H/s');
+            updateText('miners-'+poolName, localizeNumber(data.pool_statistics.miners));
             // updateText('totalFee'+poolName, calculateTotalFee(data)+'%');
 
             totalHashrate += parseInt(data.pool_statistics.hashRate);
             totalMiners += parseInt(data.pool_statistics.miners);
             updateText('totalPoolsHashrate', getReadableHashRateString(totalHashrate) + '/sec');
-            updateText('total_miners', totalMiners);
+            updateText('total_miners', localizeNumber(totalMiners));
 
             poolStats.push([poolName, data.pool_statistics.hashRate, colorHash.hex(poolName)]);
         });
         $.getJSON(url + '/network/stats', (data, textStatus, jqXHR) => {
-            updateText('height-'+poolName, data.height);
+            updateText('height-'+poolName, localizeNumber(data.height));
         });
 
         poolsRefreshed++;

--- a/pages/blockchain_block.html
+++ b/pages/blockchain_block.html
@@ -84,22 +84,22 @@
 	
 	function renderBlock(block){
 				updateText('block.hash', block.hash);
-				updateText('block.height', block.height);
+				updateText('block.height', localizeNumber(block.height));
 				updateText('block.timestamp', formatDate(block.timestamp));
 				updateText('block.version', block.major_version + '.' + block.minor_version);
-				updateText('block.difficulty', block.difficulty);
+				updateText('block.difficulty', localizeNumber(block.difficulty));
 				updateText('block.orphan', block.orphan_status ? "YES" : "NO");
 				updateText('block.transactions', block.transactions.length);
-				updateText('block.transactionsSize', block.transactionsCumulativeSize);
-				updateText('block.blockSize', block.blockSize);
-				updateText('block.currentTxsMedian', block.sizeMedian);
-				updateText('block.effectiveTxsMedian', block.effectiveSizeMedian);
+				updateText('block.transactionsSize', localizeNumber(block.transactionsCumulativeSize));
+				updateText('block.blockSize', localizeNumber(block.blockSize));
+				updateText('block.currentTxsMedian', localizeNumber(block.sizeMedian));
+				updateText('block.effectiveTxsMedian', localizeNumber(block.effectiveSizeMedian));
 				updateText('block.rewardPenalty', block.penalty*100 + "%");
 				updateText('block.baseReward', getReadableCoins(block.baseReward));
 				updateText('block.transactionsFee', getReadableCoins(block.totalFeeAmount));
 				updateText('block.reward', getReadableCoins(block.reward));
 				updateText('block.totalCoins', getReadableCoins(block.alreadyGeneratedCoins));
-				updateText('block.totalTransactions', block.alreadyGeneratedTransactions);
+				updateText('block.totalTransactions', localizeNumber(block.alreadyGeneratedTransactions));
 				renderTransactions(block.transactions);
 			
 				makePrevBlockLink(block.prev_hash);
@@ -135,7 +135,7 @@
         return '<td>' + formatPaymentLink(transaction.hash) + '</td>' +
                '<td>' + getReadableCoins(transaction.fee, 4, true) + '</td>' +
                '<td>' + getReadableCoins(transaction.amount_out, 4, true) + '</td>' +
-               '<td>' + transaction.size + '</td>';
+               '<td>' + localizeNumber(transaction.size) + '</td>';
     }
 
     function getTransactionRowElement(transaction, jsonString){

--- a/pages/blockchain_payment_id.html
+++ b/pages/blockchain_payment_id.html
@@ -66,7 +66,7 @@
         return '<td>' + formatPaymentLink(transaction.hash) + '</td>' +
                '<td>' + getReadableCoins(transaction.fee, 4, true) + '</td>' +
                '<td>' + getReadableCoins(transaction.amount_out, 4, true) + '</td>' +
-               '<td>' + transaction.size + '</td>';
+               '<td>' + localizeNumber(transaction.size) + '</td>';
     }
 
     function getTransactionRowElement(transaction, jsonString){

--- a/pages/blockchain_transaction.html
+++ b/pages/blockchain_transaction.html
@@ -108,7 +108,7 @@
                 updateText('transaction.hash', details.hash);
                 if (block.hash){
 					$('#confirmations').show();
-					updateText('transaction.confirmations', lastStats.height - block.height);
+					updateText('transaction.confirmations', localizeNumber(lastStats.height - block.height));
 					updateText('transaction.timestamp', formatDate(block.timestamp));
 					$(".transaction-timeago").timeago('update', new Date(block.timestamp * 1000).toISOString());
 				}
@@ -121,7 +121,7 @@
 				updateText('transaction.paymentIdDecifer', hex2a(details.paymentId));
                 if (!details.paymentId)
                     $('#div_transaction_paymentId').hide();
-                updateText('transaction.size', details.size);
+                updateText('transaction.size', localizeNumber(details.size));
 
 				if (!block.hash){
 					$('#tx_block').hide();
@@ -129,7 +129,7 @@
 				}
 				
                 updateTextLinkable('block.hash', formatBlockLink(block.hash));
-                updateText('block.height', block.height);
+                updateText('block.height', localizeNumber(block.height));
                 updateText('block.timestamp', formatDate(block.timestamp));
 				
                 renderInputs(inputs);

--- a/pages/home.html
+++ b/pages/home.html
@@ -103,11 +103,11 @@
 			<thead>
 			<tr>
 				<th><i class="fa fa-bars"></i> Height</th>
-				<th><i class="fa fa-clock-o"></i> Date &amp; time</th>
 				<th><i class="fa fa-archive"></i> Size</th>
 				<th><i class="fa fa-paw"></i> Block Hash</th>
 				<th><i class="fa fa-unlock-alt"></i> Difficulty</th>
 				<th><i class="fa fa-bars"></i> Txs</th>
+				<th><i class="fa fa-clock-o"></i> Date &amp; time</th>
 			</tr>
 			</thead>
 			<tbody id="blocks_rows">
@@ -149,8 +149,8 @@ currentPage = {
         },
         update: function(){
 			renderLastBlock();
-            updateText('networkHeight', lastStats.height.toString());
-            updateText('networkTransactions', lastStats.tx_count.toString());
+            updateText('networkHeight', localizeNumber(lastStats.height.toString()));
+            updateText('networkTransactions', localizeNumber(lastStats.tx_count.toString()));
             updateText('networkHashrate', getReadableHashRateString(lastStats.difficulty / blockTargetInterval));
             updateText('networkDifficulty', getReadableDifficultyString(lastStats.difficulty, 0).toString());
 			$("time.timeago").timeago();
@@ -372,12 +372,12 @@ $('#goto-height').keyup(function(e){
 		var dateTime = new Date(block.timestamp * 1000).toISOString();
 		row.setAttribute('data-dt', dateTime);
         var columns =
-            '<td>' + block.height + '</td>' +
-            '<td class="date-time">' + formatDate(block.timestamp) + ' (<time class="timeago" datetime="'+dateTime+'"></time>)</td>' +
-			'<td>' + block.cumul_size + '</td>' +
+            '<td>' + localizeNumber(block.height) + '</td>' +
+			'<td>' + localizeNumber(block.cumul_size) + '</td>' +
 			'<td>' + formatBlockLink(block.hash) + '</td>' +
-            '<td class="blk-diff">' + block.difficulty + '</td>' + 
-            '<td>' + block.tx_count + '</td>';
+            '<td class="blk-diff">' + localizeNumber(block.difficulty) + '</td>' + 
+            '<td>' + localizeNumber(block.tx_count) + '</td>' +
+            '<td class="date-time">' + formatDate(block.timestamp) + ' (<time class="timeago" datetime="'+dateTime+'"></time>)</td>';
 
 		Difficulties.push(parseInt(block.difficulty));
 		Blocks.push(parseInt(block.height));
@@ -486,7 +486,7 @@ var xhrGetPool = $.ajax({
 								/*'<td>' + formatDate(timestamp) + ' (<span class="mtx-ago"></span>)' + '</td>' +*/
 								'<td>' + getReadableCoins(amount, 4, true) + '</td>' +
 								'<td>' + getReadableCoins(fee, 4, true) + '</td>' +
-								'<td>' + size + '</td>' +
+								'<td>' + localizeNumber(size) + '</td>' +
 								'<td>' + formatPaymentLink(hash) + '</td>';
 						row.innerHTML = columns;
 						$(txsRows).append(row);


### PR DESCRIPTION
![commas](https://i.imgflip.com/27mp3o.jpg)

Localize numbers, leveraging Intl.NumberFormat.

Tested myself in FF and Chromium.
 
- Forces US style number commas. (until someone tests that it works
otherwise)
 - Made change to date format as well to condense it from the massive ISO
full date text.
 - I think I got them all :/

Closes #35 