### PR TITLE
redesign block browser pagination for better ux and cleaner design.

### DIFF
--- a/css/themes/turtle/style.css
+++ b/css/themes/turtle/style.css
@@ -115,3 +115,11 @@ table {
 thead {
         background-color: #1d1d1d;
 }
+
+#block-range-wrapper {
+        font-size: 12px;
+        line-height: 20px;
+        color: #404040;
+        float: right;
+
+}

--- a/pages/blockchain_block.html
+++ b/pages/blockchain_block.html
@@ -175,11 +175,11 @@
     }
 	
 	function makeNextBlockLink(blockHash){
-		$('#block_height').append(' <a href="' + getBlockchainUrl(blockHash) + '" title="Next block"><i class="fa fa-chevron-circle-right" aria-hidden="true"></i></a>');
+		$('#block_height').prepend('<a href="' + getBlockchainUrl(blockHash) + '" title="Next block"><i class="fa fa-chevron-circle-left" aria-hidden="true"></i></a> ');
 	}
 	
 	function makePrevBlockLink(blockHash){
-		$('#block_height').prepend('<a href="' + getBlockchainUrl(blockHash) + '" title="Previous block"><i class="fa fa-chevron-circle-left" aria-hidden="true"></i></a> ');
+		$('#block_height').append(' <a href="' + getBlockchainUrl(blockHash) + '" title="Previous block"><i class="fa fa-chevron-circle-right" aria-hidden="true"></i></a>');
 	}
 	
 	function formatPrevNextBlockLink(hash){

--- a/pages/home.html
+++ b/pages/home.html
@@ -83,38 +83,39 @@
 
 <div class="panel panel-default">
   <div class="panel-heading">
-	<h3 class="panel-title"><i class="fa fa-chain fa-fw" aria-hidden="true"></i> Recent blocks</h3>
+	<h3 class="panel-title">
+        <i class="fa fa-chain fa-fw" aria-hidden="true"></i> Recent blocks 
+        <span id="block-range-wrapper" style="float:right">Viewing Range: <span id="block-range">______ - ______</span></span>
+    </h3>
   </div>
   <div class="panel-body">
-	<div class="row">
-		<div class="col-sm-8 col-md-6 col-lg-5">
-			<div class="input-group">
-				<a id="prev-page" href="#" class="btn btn-default input-group-addon"><i class="fa fa-arrow-left" aria-hidden="true"></i> Older</a>
-				<span class="input-group-addon">№</span>
-				<input id="goto-height" type="text" class="form-control" placeholder="Height">
-				<a id="goto-height-go" href="#" class="btn btn-default input-group-addon">Go</a>
-				<a id="next-page" href="#" class="btn btn-default input-group-addon disabled">Newer <i class="fa fa-arrow-right" aria-hidden="true"></i></a>
-			</div>
-		</div>
-	</div>
 
-	<div class="table-responsive">
-		<table class="table table-hover">
-			<thead>
-			<tr>
-				<th><i class="fa fa-bars"></i> Height</th>
-				<th><i class="fa fa-archive"></i> Size</th>
-				<th><i class="fa fa-paw"></i> Block Hash</th>
-				<th><i class="fa fa-unlock-alt"></i> Difficulty</th>
-				<th><i class="fa fa-bars"></i> Txs</th>
-				<th><i class="fa fa-clock-o"></i> Date &amp; time</th>
-			</tr>
-			</thead>
-			<tbody id="blocks_rows">
+        <div class="input-group">
+            <a id="next-page" href="#" class="btn btn-default input-group-addon disabled"><i class="fa fa-arrow-left" aria-hidden="true"></i> Newer</a>
+            <span class="input-group-addon">№</span>
+            <input id="goto-height" type="text" class="form-control" placeholder="Height">
+            <a id="goto-height-go" href="#" class="btn btn-default input-group-addon">Go</a>
+            <a id="prev-page" href="#" class="btn btn-default input-group-addon">Older <i class="fa fa-arrow-right" aria-hidden="true"></i></a>
+        </div>
+        <br />
 
-			</tbody>
-		</table>
-	</div>
+        <div class="table-responsive">
+            <table class="table table-hover">
+                <thead>
+                <tr>
+                    <th><i class="fa fa-bars"></i> Height</th>
+                    <th><i class="fa fa-archive"></i> Size</th>
+                    <th><i class="fa fa-paw"></i> Block Hash</th>
+                    <th><i class="fa fa-unlock-alt"></i> Difficulty</th>
+                    <th><i class="fa fa-bars"></i> Txs</th>
+                    <th><i class="fa fa-clock-o"></i> Date &amp; time</th>
+                </tr>
+                </thead>
+                <tbody id="blocks_rows">
+
+                </tbody>
+            </table>
+        </div>
 
 	<p class="text-center">
 		<button type="button" class="btn btn-default" id="loadMoreBlocks">Load More</button>
@@ -425,7 +426,15 @@ $('#goto-height').keyup(function(e){
             }
         }
 		$("time.timeago").timeago();
+        renderBlocksPageRange(blocksResults);
 		calcAvgHashRate();
+    }
+
+    function renderBlocksPageRange(blocks) {
+        var rendered = [
+            localizeNumber(blocks[0].height), 
+            localizeNumber(blocks[blocks.length - 1].height)].join(' - ')
+        updateText('block-range', rendered);
     }
 
 	function calcAvgHashRate(){


### PR DESCRIPTION
The main changes here are

 - added a viewing range to show the range of blocks to which you're currently paged
 - swapped the newer / older page buttons to be in line with 99.9% of paginators in the world.
   - mirrored this change on the block details view as well.
 - added some web 3.0 industry standard padding.

## before
![screenshot from 2018-04-03 23-38-22](https://user-images.githubusercontent.com/33644581/38287399-7c642e6e-3798-11e8-9de3-f868d6b5b3b0.png)

## after
![screenshot from 2018-04-03 23-37-48](https://user-images.githubusercontent.com/33644581/38287404-80bc21c4-3798-11e8-96e6-acd732deee2b.png)

