### PR TITLE
progressively render the chart as data comes in

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-timeago/1.4.0/jquery.timeago.min.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-sparklines/2.1.2/jquery.sparkline.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
     <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
     <link href="css/themes/turtle/style.css" rel="stylesheet" id="theme_link">
     <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">


### PR DESCRIPTION
also, rate limit the render function. in testing usually fires 1-3 times
depending on how slow the requests to other pools are.

add underscore js as a dep, plan to use it in the future as well to
clean up and remove a bunch of hand-rolled utils. Using it to 
debounce the render function while requests are returning.

also, removed graph animations so it doesn't wind around over 
and over while the data is coming in.

closes #48 

deployed to https://explorer.trtlpwr.cc/#pools . (i'll roll back to the UX tweak in #43 after merge)